### PR TITLE
fix #10 where config.assets.gzip wasn't obeyed

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -61,6 +61,10 @@ module.exports = CoreObject.extend({
   },
 
   getS3Params: function(localFile, stat, callback) {
+    if (this.config.assets.gzip === false) {
+      return callback(null, {});
+    }
+
     var gzipExtensions = this.config.assets.gzipExtensions ? this.config.assets.gzipExtensions : ['js', 'css', 'svg'];
     var ext = localFile.replace(/.*[\.\/\\]/, '').toLowerCase();
     var isGzippedContent = gzipExtensions.indexOf(ext) != -1;

--- a/node_tests/unit/lib/s3-test.js
+++ b/node_tests/unit/lib/s3-test.js
@@ -139,7 +139,6 @@ describe('S3Adapter', function() {
 
     it('marks files with a Content-Encoding of gzip on files that are marked as gzipped', function() {
       var uploadParams = s3Adapter.getUploadParams();
-      var s3Params = uploadParams.s3Params;
 
       ['assets/my-app.js',
        'assets/my-app.css',
@@ -158,7 +157,6 @@ describe('S3Adapter', function() {
       s3Adapter.config.assets.gzip = false;
 
       var uploadParams = s3Adapter.getUploadParams();
-      var s3Params = uploadParams.s3Params;
 
       uploadParams.getS3Params('assets/my-app.js', null, function (_, additionalParams) {
         expect(additionalParams.ContentEncoding).to.eq(undefined);

--- a/node_tests/unit/lib/s3-test.js
+++ b/node_tests/unit/lib/s3-test.js
@@ -136,5 +136,33 @@ describe('S3Adapter', function() {
       var lastLine = getLastUILine(s3Adapter.ui.output);
       expect(chalk.stripColor(lastLine)).to.eq(expected);
     });
+
+    it('marks files with a Content-Encoding of gzip on files that are marked as gzipped', function() {
+      var uploadParams = s3Adapter.getUploadParams();
+      var s3Params = uploadParams.s3Params;
+
+      ['assets/my-app.js',
+       'assets/my-app.css',
+       'assets/logo.svg'].forEach(function (filename) {
+        uploadParams.getS3Params(filename, null, function (_, additionalParams) {
+          expect(additionalParams.ContentEncoding).to.eq('gzip');
+        });
+      });
+
+      uploadParams.getS3Params('assets/images/logo.png', null, function (_, additionalParams) {
+        expect(additionalParams.ContentEncoding).to.eq(undefined);
+      });
+    });
+
+    it('does not marks files with a Content-Encoding of gzip if gzip is false', function() {
+      s3Adapter.config.assets.gzip = false;
+
+      var uploadParams = s3Adapter.getUploadParams();
+      var s3Params = uploadParams.s3Params;
+
+      uploadParams.getS3Params('assets/my-app.js', null, function (_, additionalParams) {
+        expect(additionalParams.ContentEncoding).to.eq(undefined);
+      });
+    });
   });
 });


### PR DESCRIPTION
This adds tests and a fix to ensure assets are marked with the correct `Content-Encoding` when uploaded to S3
