### PR TITLE
Allow ACL to be set

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -50,7 +50,7 @@ module.exports = CoreObject.extend({
     return {
       localDir: 'tmp/assets-sync',
       s3Params: {
-        ACL: 'public-read',
+        ACL: this.config.assets.acl || 'public-read',
         Bucket: this.config.assets.bucket,
         Prefix: this.config.assets.prefix || '',
         CacheControl: 'max-age='+TWO_YEAR_CACHE_PERIOD_IN_SEC+', public',


### PR DESCRIPTION
This is important if you are using CloudFront and want to block direct s3 access.

This should probably have some tests, I just wanted to get something out ASAP.
