### PR TITLE
Remove reference to `ui.pleasantProgress`

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -31,7 +31,7 @@ module.exports = CoreObject.extend({
       return Promise.reject(new SilentError(message));
     }
 
-    this.ui.pleasantProgress.start(green('Uploading assets'), green('.'));
+    this.ui.startProgress(green('Uploading assets'), green('.'));
 
     return new Promise(function(resolve, reject) {
       var uploader = client.uploadDir(_this.getUploadParams());
@@ -107,6 +107,6 @@ module.exports = CoreObject.extend({
 
   printEndMessage: function() {
     this.ui.writeLine('Assets upload successful. Done uploading.');
-    this.ui.pleasantProgress.stop();
+    this.ui.stopProgress();
   }
 });


### PR DESCRIPTION
Ember-cli [removed `pleasantProgress` on `UI` in v2.4.3](https://github.com/ember-cli/ember-cli/pull/5612/files#diff-862010a5cfb735a85ea8db20df2b584fR35). The `startProgress`/`stopProgress` methods should be used instead (they are present at least as far back as v0.2.7 of ember-cli).